### PR TITLE
feat: update environment name to use review- prefix

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8346,7 +8346,7 @@ async function run() {
         const deployment = await octokit.rest.repos.createDeployment({
             ...context.repo,
             ref: context.ref,
-            environment: productName || "unknown",
+            environment: `review-${productName || "unknown"}`,
             transient_environment: true,
             auto_merge: false,
             required_contexts: [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "action-ephemeral-create-update",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "main": "dist/index.js",
   "repository": "git@github.com:Updater/action-ephemeral-create-update.git",
   "author": "apollorion <joey@apollorion.com>",

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ async function run() {
         const deployment = await octokit.rest.repos.createDeployment({
             ...context.repo,
             ref: context.ref,
-            environment: productName || "unknown",
+            environment: `review-${productName || "unknown"}`,
             transient_environment: true,
             auto_merge: false,
             required_contexts: [],


### PR DESCRIPTION
Following @colinrymer's input we are clarifying our environment names by prefixing them with `review-`

Related to https://github.com/Updater/action-ephemeral-delete/pull/16
